### PR TITLE
Integração do serviço de LaunchPad e navegação para tela de detalhes

### DIFF
--- a/solutions/devsprint-gabriel-marcos-1/app/src/main/java/com/devpass/spaceapp/data/api/SpaceXAPIClient.kt
+++ b/solutions/devsprint-gabriel-marcos-1/app/src/main/java/com/devpass/spaceapp/data/api/SpaceXAPIClient.kt
@@ -1,5 +1,6 @@
 package com.devpass.spaceapp.data.api
 
+import com.devpass.spaceapp.data.model.LaunchPadModel
 import com.devpass.spaceapp.data.model.RocketModel
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
@@ -10,6 +11,9 @@ interface SpaceXAPIClient {
 
     @GET("v4/rockets/{id}")
     suspend fun getRocketDetails(@Path("id") id: String): RocketModel
+
+    @GET("v4/launchpads/{id}")
+    suspend fun getLaunchpadDetails(@Path("id") id: String): LaunchPadModel
 
     companion object {
         private const val BASE_URL = "https://api.spacexdata.com/"

--- a/solutions/devsprint-gabriel-marcos-1/app/src/main/java/com/devpass/spaceapp/data/model/LaunchPadModel.kt
+++ b/solutions/devsprint-gabriel-marcos-1/app/src/main/java/com/devpass/spaceapp/data/model/LaunchPadModel.kt
@@ -1,0 +1,23 @@
+package com.devpass.spaceapp.data.model
+
+import com.google.gson.annotations.SerializedName
+import java.io.Serializable
+
+data class LaunchPadModel (
+    @SerializedName("id")
+    val id: String,
+    @SerializedName("name")
+    val name: String,
+    @SerializedName("locality")
+    val locality: String,
+    @SerializedName("region")
+    val region: String,
+    @SerializedName("latitude")
+    val latitude: Double,
+    @SerializedName("longitude")
+    val longitude: Double,
+    @SerializedName("launch_attempts")
+    val launchAttempts: Int,
+    @SerializedName("launch_successes")
+    val launchSuccesses: Int
+) : Serializable

--- a/solutions/devsprint-gabriel-marcos-1/app/src/main/java/com/devpass/spaceapp/data/repository/SpaceAppRepository.kt
+++ b/solutions/devsprint-gabriel-marcos-1/app/src/main/java/com/devpass/spaceapp/data/repository/SpaceAppRepository.kt
@@ -1,8 +1,10 @@
 package com.devpass.spaceapp.data.repository
 
+import com.devpass.spaceapp.data.model.LaunchPadModel
 import com.devpass.spaceapp.data.model.RocketModel
 
 interface SpaceAppRepository {
 
     suspend fun getRocketDetails(id: String): Result<RocketModel>
+    suspend fun getLaunchpadDetails(id: String): Result<LaunchPadModel>
 }

--- a/solutions/devsprint-gabriel-marcos-1/app/src/main/java/com/devpass/spaceapp/data/repository/SpaceAppRepositoryImpl.kt
+++ b/solutions/devsprint-gabriel-marcos-1/app/src/main/java/com/devpass/spaceapp/data/repository/SpaceAppRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.devpass.spaceapp.data.repository
 
 import com.devpass.spaceapp.data.api.SpaceXAPIClient
+import com.devpass.spaceapp.data.model.LaunchPadModel
 import com.devpass.spaceapp.data.model.RocketModel
 
 class SpaceAppRepositoryImpl(
@@ -10,6 +11,15 @@ class SpaceAppRepositoryImpl(
     override suspend fun getRocketDetails(id: String): Result<RocketModel> {
         return try {
             val result = service.getRocketDetails(id)
+            Result.success(result)
+        } catch (error: Exception) {
+            Result.failure(error)
+        }
+    }
+
+    override suspend fun getLaunchpadDetails(id: String): Result<LaunchPadModel> {
+        return try {
+            val result = service.getLaunchpadDetails(id)
             Result.success(result)
         } catch (error: Exception) {
             Result.failure(error)

--- a/solutions/devsprint-gabriel-marcos-1/app/src/main/java/com/devpass/spaceapp/presentation/LaunchTabAdapter.kt
+++ b/solutions/devsprint-gabriel-marcos-1/app/src/main/java/com/devpass/spaceapp/presentation/LaunchTabAdapter.kt
@@ -9,7 +9,7 @@ class LaunchTabAdapter(fa: FragmentActivity) :
     FragmentStateAdapter(fa) {
 
     val tabTitles = listOf(R.string.tab_title_one, R.string.tab_title_two, R.string.tab_title_three)
-    private val fragments = listOf(DetailsFragment(), RocketFragment(), LaunchpadFragment())
+    private val fragments = listOf(DetailsFragment(), RocketFragment(), LaunchpadFragment("5e9e4502f509092b78566f87"))
 
     override fun getItemCount(): Int {
         return tabTitles.size

--- a/solutions/devsprint-gabriel-marcos-1/app/src/main/java/com/devpass/spaceapp/presentation/LaunchpadDetailsActivity.kt
+++ b/solutions/devsprint-gabriel-marcos-1/app/src/main/java/com/devpass/spaceapp/presentation/LaunchpadDetailsActivity.kt
@@ -2,11 +2,14 @@ package com.devpass.spaceapp.presentation
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import com.devpass.spaceapp.R
+import com.devpass.spaceapp.data.model.LaunchPadModel
 import com.devpass.spaceapp.databinding.ActivityLaunchPadDetailsBinding
 
 class LaunchpadDetailsActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityLaunchPadDetailsBinding
+    private lateinit var launchPad: LaunchPadModel
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -15,7 +18,14 @@ class LaunchpadDetailsActivity : AppCompatActivity() {
 
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
-        setup()
+        getIntentExtra()
+        dataSetup()
+    }
+
+    private fun getIntentExtra() {
+        intent?.let {
+            launchPad = it.getSerializableExtra("launchpad") as LaunchPadModel
+        }
     }
 
     override fun onSupportNavigateUp(): Boolean {
@@ -23,16 +33,16 @@ class LaunchpadDetailsActivity : AppCompatActivity() {
         return true
     }
 
-    private fun setup() {
+    private fun dataSetup() {
 
-        title = "VAFB SLC 4E"
+        title = launchPad.name
 
         binding.apply {
-            name.text = "VAFB SLC 4E"
-            locality.text = "Vandenberg Air Force Base"
-            region.text = "California"
-            launchAttempts.text = "Launch Attempts: 15"
-            launchSuccesses.text = "Launch Successes: 15"
+            name.text = launchPad.name
+            locality.text = launchPad.locality
+            region.text = launchPad.region
+            launchAttempts.text = "${getString(R.string.launch_attempts)} ${launchPad.launchAttempts}"
+            launchSuccesses.text = "${getString(R.string.launch_success)} ${launchPad.launchSuccesses}"
         }
     }
 }

--- a/solutions/devsprint-gabriel-marcos-1/app/src/main/java/com/devpass/spaceapp/presentation/LaunchpadFragment.kt
+++ b/solutions/devsprint-gabriel-marcos-1/app/src/main/java/com/devpass/spaceapp/presentation/LaunchpadFragment.kt
@@ -1,42 +1,66 @@
 package com.devpass.spaceapp.presentation
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 import androidx.fragment.app.Fragment
 import com.devpass.spaceapp.R
+import com.devpass.spaceapp.data.model.LaunchPadModel
 import com.devpass.spaceapp.databinding.FragmentLaunchpadBinding
+import org.koin.androidx.viewmodel.ext.android.viewModel
 
-class LaunchpadFragment : Fragment(R.layout.fragment_launchpad) {
+class LaunchpadFragment (
+    private val idLaunchPad: String
+    ) : Fragment() {
 
     private lateinit var binding: FragmentLaunchpadBinding
+    private val viewModel: SpaceAppViewModel by viewModel()
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
+    ): View {
+        super.onCreateView(inflater, container, savedInstanceState)
+
         binding = FragmentLaunchpadBinding.inflate(inflater, container, false)
+
+        viewModel.getLaunchpadDetails(idLaunchPad)
+
         return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        setup()
+        binding.loading.show()
+        dataSetup()
     }
 
-    private fun setup() {
-        binding.apply {
-            name.text = "VAFB SLC 4E"
-            locality.text = "Vandenberg Air Force Base"
-            region.text = "California"
-            viewMore.setOnClickListener {
-                Toast.makeText(requireContext(), "Abrir próxima tela", Toast.LENGTH_SHORT)
-                    .show()
-            }
+    private fun configureClickable(launchPadModel: LaunchPadModel) {
+        binding.viewMore.setOnClickListener {
+            val intent = Intent(context, LaunchpadDetailsActivity::class.java)
+            intent.putExtra("launchpad", launchPadModel)
+            startActivity(intent)
         }
     }
 
+    private fun dataSetup() {
+        viewModel.resultLaunchpadDetails.observe(viewLifecycleOwner) {
+            if (it != null) {
+                binding.name.text = it.name
+                binding.locality.text = it.locality
+                binding.region.text = it.region
+                configureClickable(it)
+                binding.cardView.visibility = View.VISIBLE
+            } else {
+                binding.viewMore.visibility = View.GONE
+                binding.error.errorMessage.text = getString(R.string.launchpad_details_fail)
+                binding.error.root.visibility = View.VISIBLE
+            }
+
+            binding.loading.hide()
+        }
+    }
 }

--- a/solutions/devsprint-gabriel-marcos-1/app/src/main/java/com/devpass/spaceapp/presentation/SpaceAppViewModel.kt
+++ b/solutions/devsprint-gabriel-marcos-1/app/src/main/java/com/devpass/spaceapp/presentation/SpaceAppViewModel.kt
@@ -3,6 +3,7 @@ package com.devpass.spaceapp.presentation
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.devpass.spaceapp.data.model.LaunchPadModel
 import com.devpass.spaceapp.data.model.RocketModel
 import com.devpass.spaceapp.data.repository.SpaceAppRepository
 import kotlinx.coroutines.launch
@@ -12,6 +13,7 @@ class SpaceAppViewModel(
 ) : ViewModel() {
 
     val resultRocketDetails = MutableLiveData<RocketModel?>()
+    val resultLaunchpadDetails = MutableLiveData<LaunchPadModel?>()
 
     fun getRocketDetails(id: String) {
         viewModelScope.launch {
@@ -21,6 +23,18 @@ class SpaceAppViewModel(
                 }
                 .onFailure {
                     resultRocketDetails.value = null
+                }
+        }
+    }
+
+    fun getLaunchpadDetails(id: String) {
+        viewModelScope.launch {
+            repository.getLaunchpadDetails(id)
+                .onSuccess {
+                    resultLaunchpadDetails.value = it
+                }
+                .onFailure {
+                    resultLaunchpadDetails.value = null
                 }
         }
     }

--- a/solutions/devsprint-gabriel-marcos-1/app/src/main/res/layout/activity_launch_pad_details.xml
+++ b/solutions/devsprint-gabriel-marcos-1/app/src/main/res/layout/activity_launch_pad_details.xml
@@ -3,7 +3,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    tools:context=".presentation.LaunchpadDetailsActivity">
 
     <ImageView
         android:id="@+id/map"
@@ -13,7 +14,8 @@
         android:src="@drawable/ic_launcher_background"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        android:contentDescription="@string/launchpad_image" />
 
     <TextView
         android:id="@+id/name"
@@ -46,13 +48,13 @@
         android:id="@+id/launch_attempts"
         style="@style/Theme.SpaceApp.TextNormal"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/launch_successes"
+        app:layout_constraintTop_toBottomOf="@+id/region"
         tools:text="Launch Attempts: 15" />
 
     <TextView
         android:id="@+id/launch_successes"
         style="@style/Theme.SpaceApp.TextNormal"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/region"
+        app:layout_constraintTop_toBottomOf="@+id/launch_attempts"
         tools:text="Launch Successes: 15" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/solutions/devsprint-gabriel-marcos-1/app/src/main/res/layout/error.xml
+++ b/solutions/devsprint-gabriel-marcos-1/app/src/main/res/layout/error.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:padding="16dp">
 
     <TextView
         android:id="@+id/error_message"

--- a/solutions/devsprint-gabriel-marcos-1/app/src/main/res/layout/fragment_launchpad.xml
+++ b/solutions/devsprint-gabriel-marcos-1/app/src/main/res/layout/fragment_launchpad.xml
@@ -7,18 +7,39 @@
     android:background="@color/color_white"
     tools:context=".presentation.LaunchpadFragment">
 
+    <include
+        android:id="@+id/error"
+        layout="@layout/error"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:visibility="gone" />
+
+    <androidx.core.widget.ContentLoadingProgressBar
+        android:id="@+id/loading"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        style="?android:attr/progressBarStyle"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        android:visibility="visible" />
 
     <androidx.cardview.widget.CardView
+        android:id="@+id/card_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
         android:layout_marginTop="32dp"
         android:layout_marginEnd="16dp"
-        android:layout_marginBottom="16dp"
+        android:layout_marginBottom="32dp"
         app:cardCornerRadius="@dimen/card_radius"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.0"
+        android:visibility="gone">
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -52,7 +73,7 @@
                 android:layout_marginStart="16dp"
                 android:layout_marginTop="16dp"
                 android:layout_marginBottom="8dp"
-                android:text="VIEW MORE"
+                android:text="@string/view_more_click"
                 android:textAllCaps="true"
                 android:textColor="@color/color_primary_blue_02"
                 android:textSize="14sp" />

--- a/solutions/devsprint-gabriel-marcos-1/app/src/main/res/values/strings.xml
+++ b/solutions/devsprint-gabriel-marcos-1/app/src/main/res/values/strings.xml
@@ -9,4 +9,8 @@
     <string name="description">SpaceX\'s 20th and final Crew Resupply Mission under the original NASA CRS contract, this mission brings essential supplies to the International Space Station using SpaceX\'s reusable Dragon spacecraft. It is the last scheduled flight of a Dragon 1 capsule. (CRS-21 and up under the new Commercial Resupply Services 2 contract will use Dragon 2.) The external payload for this mission is the Bartolomeo ISS external payload hosting platform. Falcon 9 and Dragon will launch from SLC-40, Cape Canaveral Air Force Station and the booster will land at LZ-1. The mission will be complete with return and recovery of the Dragon capsule and down cargo.</string>
     <string name="rocket_image">Rocket Image</string>
     <string name="rocket_details_fail">Rocket details not found</string>
+    <string name="launchpad_details_fail">LaunchPad details not found</string>
+    <string name="launch_attempts">Launch Attempts:</string>
+    <string name="launch_success">Launch Successes:</string>
+    <string name="launchpad_image">Launchpad image</string>
 </resources>


### PR DESCRIPTION
### Descrição e Solução
- Integração do serviço que obtém os dados do LaunchPad;
- Navegação da tela de detalhes do lançamento para os detalhes do LaunchPad;
 
### Checklist:
- [x] Não adiciona código duplicado
- [x] Não contém código comentado
- [x] Não contém código WIP
- [ ] Teste Unitário Implementado
 
### Evidências:

![Screenshot from 2022-05-27 07-16-13](https://user-images.githubusercontent.com/20290428/170680812-ca848a27-9a41-450a-a202-a6707ad22a23.png) | ![Screenshot from 2022-05-27 07-16-29](https://user-images.githubusercontent.com/20290428/170680911-e8c38f6c-dd57-41bd-827b-ef735a5fb9fb.png)

