### PR TITLE
Add git ignore para evitar subir arquivos locais para o repo

### DIFF
--- a/solutions/devsprint-roque-buarque-1/app/.gitignore
+++ b/solutions/devsprint-roque-buarque-1/app/.gitignore
@@ -1,1 +1,33 @@
-/build
+# Gradle files
+.gradle/
+build/
+
+# Local configuration file (sdk path, etc)
+local.properties
+
+# Log/OS Files
+*.log
+
+# Android Studio generated files and folders
+captures/
+.externalNativeBuild/
+.cxx/
+*.apk
+output.json
+
+# IntelliJ
+*.iml
+.idea/
+misc.xml
+deploymentTargetDropDown.xml
+render.experimental.xml
+
+# Keystore files
+*.jks
+*.keystore
+
+# Google Services (e.g. APIs or Firebase)
+google-services.json
+
+# Android Profiling
+*.hprof


### PR DESCRIPTION
### Descrição e Solução
- Começamos a trabalhar em equipe e abrir nossos primeiros PRs, porém o `gitignore` do projeto apenas estava excluindo arquivos da past `/build`. Esse PR adiciona alguns outros diretórios que não queremos subir para o repositório do projeto. 
 
### Checklist:
- [x] Não adiciona código duplicado
- [x] Não contém código comentado
- [x] Não contém código WIP
- [x] Teste Unitário Implementado(Não se aplica)
 
### Evidências:
Não tem nenhuma mudança de UI
