### PR TITLE
Add viewModelActivityScope to NextLaunchesActivity 

### DIFF
--- a/solutions/devsprint-gabriel-goto-1/app/build.gradle
+++ b/solutions/devsprint-gabriel-goto-1/app/build.gradle
@@ -47,6 +47,8 @@ android {
 
 dependencies {
 
+    //Android
+    implementation 'androidx.fragment:fragment-ktx:1.5.2'
     implementation 'androidx.core:core-ktx:1.8.0'
     implementation 'androidx.appcompat:appcompat:1.4.2'
     implementation 'com.google.android.material:material:1.6.1'

--- a/solutions/devsprint-gabriel-goto-1/app/src/main/java/com/devpass/spaceapp/presentation/NextLaunchesActivity.kt
+++ b/solutions/devsprint-gabriel-goto-1/app/src/main/java/com/devpass/spaceapp/presentation/NextLaunchesActivity.kt
@@ -1,19 +1,18 @@
 package com.devpass.spaceapp.presentation
 
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.view.View
-import androidx.lifecycle.viewModelScope
+import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.devpass.spaceapp.R
-import com.devpass.spaceapp.data.model.LaunchesResponse
 import com.devpass.spaceapp.databinding.ActivityMainBinding
 import com.devpass.spaceapp.infra.NetworkResult
 import com.google.android.material.snackbar.Snackbar
 
 class NextLaunchesActivity : AppCompatActivity() {
 
-    private val viewModel = NextLaunchesViewModel()
+    private val viewModel by viewModels<NextLaunchesViewModel>()
     private lateinit var adapter: NextLaunchesAdapter
 
     private val binding: ActivityMainBinding by lazy {
@@ -49,7 +48,6 @@ class NextLaunchesActivity : AppCompatActivity() {
                 is NetworkResult.Error -> {
                     binding.loading.visibility = View.GONE
                     snackBarError
-
                 }
             }
         }


### PR DESCRIPTION
### Descrição e Solução
- Adicionada dependencia `androidx.fragment:fragment-ktx`
- Adicionado `viewModelActivityScope` a `NextLaunchesActivity`.
 
### Checklist:
- [x] Não adiciona código duplicado
- [x] Não contém código comentado
- [x] Não contém código WIP
- [ ] Teste Unitário Implementado
 
### Evidências:
<img width="577" alt="image" src="https://user-images.githubusercontent.com/62452017/185514713-b632095d-fa3b-4ebe-850a-b3358ac9be8b.png">